### PR TITLE
Don't prime speech api on ChromeOS

### DIFF
--- a/src/morse/morse.ts
+++ b/src/morse/morse.ts
@@ -355,8 +355,10 @@ export class MorseViewModel {
       this.runningPlayMs(0)
       // clear the voice cache
       this.voiceBuffer = []
-      // prime the pump for safari
-      this.morseVoice.primeThePump()
+      if (this.morseVoice.voiceEnabled() && navigator.userAgent.indexOf('CrOS') === -1) {
+        // prime the pump for safari
+        this.morseVoice.primeThePump()
+      }
       // clear the card buffer
       this.cardBufferManager.clear()
       this.charsPlayed(0)


### PR DESCRIPTION
Disables the 'prime the pump' workaround for the speech api when voice is disabled and at all times on ChromeOS.

Fixes: #134