### PR TITLE
1.0.9 accessibility improvements stage one

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -21,3 +21,35 @@ noiseaccordion {
     width: 1px;
 }
 
+#contributor-info {
+    display: block;
+    margin-bottom: .5rem;
+    font-size: calc(1.3rem + .6vw);
+    font-size: 1.75rem;
+    font-weight: 500;
+    line-height: 1.2;
+}
+
+#credits-and-info>span {
+    display: block;
+    margin-top: 0;
+    margin-bottom: .5rem;
+    font-weight: 500;
+    font-size: 1rem;
+    line-height: 1.2;
+    box-sizing: border-box;
+}
+
+#credits-and-info>span#contributor-info, #credits-and-info>span.warning {
+    font-size: calc(1.3rem + .6vw);
+}
+
+@media (min-width: 1200px) {
+    #contributor-info {
+        font-size: 1.75rem;
+    }
+
+    #credits-and-info>span#contributor-info, #credits-and-info>span.warning {
+        font-size: 1.75rem;
+    }
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -48,6 +48,19 @@ section:last-of-type {
     font-size: calc(1.3rem + .6vw);
 }
 
+#keyboard-shortcuts table thead tr {
+    background-color: #e7f1ff;
+}
+
+#keyboard-shortcuts table th, #keyboard-shortcuts table td {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
+#keyboard-shortcuts table td.key {
+    text-align: right;
+}
+
 @media (min-width: 1200px) {
     #contributor-info {
         font-size: 1.75rem;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -21,6 +21,10 @@ noiseaccordion {
     width: 1px;
 }
 
+section:last-of-type {
+    padding-bottom: 2rem;
+}
+
 #contributor-info {
     display: block;
     margin-bottom: .5rem;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,0 +1,23 @@
+simpleimage {
+    display: contents;
+}
+
+noiseaccordion {
+    display: contents;
+}
+
+/*
+ * The sr-only class indicates content that is meant only for screen readers
+ * and which should not be rendered on a graphical display.
+ */
+.sr-only {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 // they are used by the accordian.
 // eslint-disable-next-line no-unused-vars
 import { Tooltip, Toast, Popover } from 'bootstrap'
+import './css/style.css'
 import { MorseViewModel } from './morse/morse.ts'
 
 ko.applyBindings(new MorseViewModel())

--- a/src/morse/shortcutKeys/morseShortcutKeys.ts
+++ b/src/morse/shortcutKeys/morseShortcutKeys.ts
@@ -1,52 +1,58 @@
 import { MorseSettings } from '../settings/settings'
 
+class ShortcutHandler {
+    key: string
+    title:string
+    handler:VoidFunction
+
+    constructor (key:string, title:string, handler:VoidFunction) {
+      this.key = key
+      this.title = title
+      this.handler = handler
+    }
+}
+
 export class MorseShortcutKeys {
-  morseSettings:MorseSettings
-  constructor (morseSettings:MorseSettings) {
-    this.morseSettings = morseSettings
+  registeredHandlers:Array<ShortcutHandler>
+  registrationCallback:(key:string, title:string) => void
+  
+  /**
+   * Instantiates a new MorseShortcutKeys instance
+   * 
+   * @param registrationCallback A callback that is called whenever a new shortcut key is registered.
+   */
+  constructor (registrationCallback:(key:string, title:string) => void) {
+    this.registrationCallback = registrationCallback
+    this.registeredHandlers = []
+
     // add the shortcut key listener
     document.addEventListener('keypress', (e) => {
       const tagName = (<any>e.target).tagName
       if (tagName !== 'INPUT' && tagName !== 'TEXTAREA') {
-        // var input = document.querySelector(".my-input");
-        // input.focus();
-        // input.value = e.key;
-        // console.log(e.target.tagName)
-        // console.log(e.key)
         this.routeShortcutKey(e.key)
         e.preventDefault()
       }
     })
   }
 
-  routeShortcutKey = (key) => {
+  routeShortcutKey = (key:string) => {
     // console.log('routing shortcut key')
-    switch (key) {
-      case 'z':
-        this.changeFarnsworth(-1)
-        break
-      case 'x':
-        this.changeFarnsworth(1)
-        break
+    const handler:ShortcutHandler = this.registeredHandlers[key]
+    if (handler != undefined) {
+      handler.handler()
     }
   }
 
-  changeFarnsworth = (x) => {
-    // console.log('changing farnsworth')
-    const newWpm = parseInt(this.morseSettings.speed.wpm() as any) + x
-    const newFwpm = parseInt(this.morseSettings.speed.fwpm() as any) + x
-    if (newWpm < 1 || newFwpm < 1) {
-      return
-    }
-
-    if (this.morseSettings.speed.syncWpm()) {
-      this.morseSettings.speed.wpm(newWpm)
-      return
-    }
-
-    if (newFwpm > this.morseSettings.speed.wpm()) {
-      this.morseSettings.speed.wpm(newWpm)
-    }
-    this.morseSettings.speed.fwpm(newFwpm)
+  /**
+   * Registers a shortcut key, which when pressed will call the provided handler
+   * 
+   * @param key The shortcut key, such as 'z'
+   * @param title A brief description of the shortcut's function
+   * @param handler The handler to be called in response to pressing the shortcut key
+   */
+  registerShortcutKeyHandler = (key:string, title:string, handler:VoidFunction) => {
+    const shortcutHandler = new ShortcutHandler(key, title, handler)
+    this.registeredHandlers[key] = shortcutHandler
+    this.registrationCallback(key, title)
   }
 }

--- a/src/template.html
+++ b/src/template.html
@@ -860,8 +860,27 @@
 
             </section>
 
+            <details id="keyboard-shortcuts">
+                <summary>Keyboard Shortcuts</summary>
+                <p>
+                    The following keyboard shortcuts are available to help access commonly used features.
+                </p>
+                <table>
+                    <thead>
+                        <tr><th>Keyboard shortcut</th><th>Function</th></tr>
+                    </thead>
+                    <tbody data-bind="foreach: allShortcutKeys">
+                        <tr><td class="key"><span data-bind="text: $data.key"></td><td class="function" data-bind="text: $data.title"></td></tr>
+                    </tbody>
+                </table>
+            </details>
+            <br>
+            <br>
         </div>
 
+        <status class="sr-only" aria-live="polite" aria-label="Latest status announcement">
+            <p data-bind="text: accessibilityAnnouncement()"></p>
+        </status>
 
     </div>
 </body>

--- a/src/template.html
+++ b/src/template.html
@@ -25,26 +25,6 @@
                     'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', 'GTM-PB8HW3M');</script>
     <!-- End Google Tag Manager -->
-    <style>
-        simpleimage {
-            display: contents;
-        }
-
-        noiseaccordion {
-            display: contents;
-        }
-
-        .sr-only {
-            border: 0;
-            clip: rect(0 0 0 0);
-            height: 1px;
-            margin: -1px;
-            overflow: hidden;
-            padding: 0;
-            position: absolute;
-            width: 1px;
-        }
-    </style>
 </head>
 
 <body>

--- a/src/template.html
+++ b/src/template.html
@@ -38,32 +38,21 @@
             <header class="col">
                 <div class="row row-cols-2 justify-content-md-center">
                     <div class="col col-md-auto">
-                        <img id="logoImage" height="200px" width="200px" alt="LICW Logo" />
+                        <img id="logoImage" height="200px" width="200px" alt="Long Island CW Club Logo depicting a hand on a straight key and the club call sign W2LCW" />
 
                     </div>
                     <div class="col col-md-auto">
                         <h1>Morse Practice Page</h1>
-                        <h3>by KN4YRM with assistance from AB5TN, KN6WKV, N1CC, VE3QBZ, VK5PL, WO6W, and W4YES</h3>
-                        <h6>Inspired by and adapted from the <a href="https://morsecode.world/">SC Phillips</a> <a
-                                href="https://github.com/scp93ch/morse-pro">morse-pro</a> library.
-                            To view source, please go to our <a
-                                href="https://github.com/LongIslandCW/morsebrowser/">github<img id="githubImage">
-                                repository.</a></h6>
-                        <h6>To ask user questions, report bugs, request features and more <a
-                                href="mailto:MorsePracticePageQuestions@groups.io">email us</a> or join our <a
-                                href="https://groups.io/g/MorsePracticePageQuestions">groups.io</a>. </h6>
-                        <h6>Videos to help you use this site are found <a
-                                href="https://www.youtube.com/playlist?list=PLyARUjdG9q-Xywoch5QJRGfgPZTucfhfB">here.</a>
-                        </h6>
-
-
-
-                        <h3 data-bind="if: isDev()">WARNING: You are using the BETA (unstable) version. For the latest
-                            stable release please <a href="../">click here.</a></h3>
-                        <h6>Version 1.0.9</h6>
+                        <section id="credits-and-info" title="Credits and additional information" aria-label="Credits and additional information">
+                            <span title="Contributor info" id="contributor-info">by KN4YRM with assistance from AB5TN, KN6WKV, N1CC, VE3QBZ, VK5PL, WO6W, and W4YES</span>
+                            <span>Inspired by and adapted from the <a href="https://morsecode.world/">SC Phillips</a> <a href="https://github.com/scp93ch/morse-pro">morse-pro library</a>. To view source, please go to <a href="https://github.com/LongIslandCW/morsebrowser/">our github<img id="githubImage" aria-hidden="true"> repository.</a></span>
+                            <span>To ask user questions, report bugs, request features and more <a href="mailto:MorsePracticePageQuestions@groups.io">email us</a> or join <a href="https://groups.io/g/MorsePracticePageQuestions">our groups.io</a>.</span>
+                            <span><a href="https://www.youtube.com/playlist?list=PLyARUjdG9q-Xywoch5QJRGfgPZTucfhfB">Videos to help you use this site</a> are found on YouTube</span>
+                            <span class="warning" data-bind="if: isDev()">WARNING: You are using the BETA (unstable) version. The <a href="../">latest stable release</a> is recommended.</a></span>
+                            <span id="version-info">Version 1.0.9</span>
+                        </section>
                     </div>
                 </div>
-
             </header>
 
             <!-- settings area-->
@@ -115,7 +104,6 @@
 
                 </div>
             </section>
-
 
             <!-- working text area-->
             <section class="col" aria-label="Working text">

--- a/src/template.html
+++ b/src/template.html
@@ -56,7 +56,7 @@
             </header>
 
             <!-- settings area-->
-            <section class="col" aria-label="Basic settings">
+            <section class="col" title="Basic settings" aria-label="Basic settings">
                 <div class="row row-cols-2 gx-2 gy-2">
                     <!--wpm/fwpm-->
                     <div class="col-md-auto">
@@ -106,7 +106,7 @@
             </section>
 
             <!-- working text area-->
-            <section class="col" aria-label="Working text">
+            <section class="col" title="Working text" aria-label="Working text">
                 <div class="row">
                     <div class="col">
                         <div class="input-group">
@@ -200,7 +200,7 @@
             </section>
 
             <!--  accordian area -->
-            <section aria-label="Settings" class="col">
+            <section title="Settings" aria-label="Settings" class="col">
                 <div class="accordion" id="accordionArea">
                     <!-- lessons -->
                     <div class="accordion-item">
@@ -764,9 +764,8 @@
             </section>
 
             <!-- controls area -->
-            <section aria-label="Playback" class="col">
+            <section class="col btn-toolbar" aria-label="Playback controls">
 
-                <div class="btn-toolbar" role="toolbar" aria-label="Playback controls">
                     <div class="btn-group me-2" role="group">
                         <!-- play button -->
                         <button id="btnPlayButton" type="button" class="btn btn-success" aria-label="Play"
@@ -796,7 +795,7 @@
                             1&nbsp;<img height="20" width="20"
                                 data-bind="attr:{src: morseLoadImages().getSrc('skipbackImage') }"></button>
                         <button id="btnFullRewind" type="button" class="btn btn-success"
-                            data-bind="click: fullRewind">Full
+                            data-bind="click: fullRewind" aria-label="Full rewind">Full
                             RW&nbsp;<img id="skipstartImage" height="20" width="20" /></button>
                         <button id="btnFwd1" type="button" class="btn btn-secondary"
                             data-bind="click: incrementIndex">Fwd
@@ -814,10 +813,6 @@
 
                     </div>
                     <div class="btn-group me-2" role="group">
-                        <!-- 
-                                <input type="checkbox" data-bind="checked: showRaw" class="btn-check" id="btnShowRaw" autocomplete="off"/>
-                                <label class="btn btn-outline-primary" for="btnShowRaw">Show Raw Text</label>
-                                -->
                         <input aria-label="Hide cards" type="checkbox" data-bind="checked: hideList" class="btn-check"
                             id="btnHideList" autocomplete="off" />
                         <label aria-hidden="true" class="btn btn-outline-primary"
@@ -830,8 +825,7 @@
 
                         <button id="btnShuffle" type="button" class="btn btn-secondary"
                             data-bind="click: () => shuffleWords(false)"><span
-                                data-bind="text: isShuffled()?'UnShuffle':'Shuffle'"></span>&nbsp;<img alt=""
-                                id="shuffleImage" height="20" width="20"></button>
+                                data-bind="text: isShuffled()?'UnShuffle':'Shuffle'"></span>&nbsp;<img alt="" id="shuffleImage" height="20" width="20"></button>
 
                     </div>
 
@@ -846,9 +840,6 @@
                                 data-bind="attr:{ src: loop() ? morseLoadImages().getSrc('checkImage') : morseLoadImages().getSrc('circleImage')}" /></label>
                     </div>
 
-
-                </div>
-
             </section>
 
 
@@ -860,11 +851,9 @@
                     <div class="col-auto">
                         <button class="btn"
                             data-bind="class: $index()==$parent.currentIndex() ? ($index()==$parent.words().length-1 ? 'btn-danger' : 'btn-primary'): ($index()==$parent.words().length-1 ? 'btn-outline-danger' : 'btn-outline-primary' ) ,click:()=>$parent.flaggedWords.addFlaggedWord($data), event:{dblclick: ()=>{$parent.setWordIndex($index())}}">
-                            <!--<h1>-->
                             <span
                                 data-bind="style: {fontSize: $parent.cardFontPx } ,text: (!$parent.hideList() || ($parent.trailReveal() && $index() &lt;= $parent.maxRevealedTrail() )) ? $data.displayWord : 'X'.repeat($data.displayWord.replace('\r','').replace('\n','').trim().length)">
                             </span>
-                            <!--</h1>-->
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
This is the first set of accessibility improvements I'm hoping to include in the next release. The focus on these improvements is based on feedback from our meetings with Chris:

- The credits/information included in the header are no longer headings themselves
- I added a section around said credits/information. We can still play around with the idea of moving parts of this to a footer.
- Links have been updated to provided richer descriptions of what they link to, instead of "click here", etc
- Added several keyboard shortcuts for common operations (play/pause, advance/rewind, toggle visibility, shuffle, etc). I've used YouTube's shortcuts as a starting point and have tried to stick to using keys they use (presuming that they have also tried to avoid interfering with screenreaders/other shortcuts). In a future update, we can provide the ability to remap shortcuts to ones preference.
- Added support for announcing status changes to screen readers using an ARIA live region. This allows us to provide feedback when one uses a toggle shortcut key and the impact isn't otherwise obvious, for example.

Still to do in stage two: Overhaul of "More Settings" and "Flagged Cards" sections. Also would like to have a discussion about what's in "Visual and Auditory Accessibility" and whether that's an appropriate name for the section.