### PR TITLE
Fix security issues thrown up by npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "webpack": "^5.68.0",
         "webpack-cli": "^4.9.2",
         "white-noise-node": "^1.1.1",
-        "xml2js": "^0.4.23",
+        "xml2js": "^0.6.0",
         "zip-a-folder": "^1.1.3"
       },
       "devDependencies": {
@@ -8707,9 +8707,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -15065,9 +15065,9 @@
       "requires": {}
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "webpack": "^5.68.0",
     "webpack-cli": "^4.9.2",
     "white-noise-node": "^1.1.1",
-    "xml2js": "^0.4.23",
+    "xml2js": "^0.6.0",
     "zip-a-folder": "^1.1.3"
   },
   "scripts": {


### PR DESCRIPTION
Building with npm threw up several security issues.

The only package which had to be force upgraded was `xml2js`, but there is no changelog for the project and no details on the release so I think they are not using semantic versioning so this should be fine.