### PR TITLE
deleted OR

### DIFF
--- a/src/wordfiles/TIN8.txt
+++ b/src/wordfiles/TIN8.txt
@@ -2,7 +2,6 @@ AR
 {IN|indiana} 
 IA 
 NE 
-{OR|oregon} 
 RI 
 TN 
 UT 


### PR DESCRIPTION
OR appears in lesson "TIN REA UWB STATES", but there is no letter 'O' in this letter group.