### PR TITLE
[N4DXS] Allow linking to lessons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "morse_browser",
+  "name": "MPP",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "MPP",
+  "name": "morsebrowser",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "morsebrowser",
+  "name": "morse_browser",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/morse/lessons/morseLessonPlugin.ts
+++ b/src/morse/lessons/morseLessonPlugin.ts
@@ -203,6 +203,11 @@ export default class MorseLessonPlugin implements ICookieHandler {
     var idx = 1 // first item is always empty
     console.log(chunks)
 
+    // remove leading /morsebrowser (if present)
+    if (chunks[idx].toLowerCase() === 'morsebrowser') {
+        idx++
+    }
+
     // handle /dev if present (must be first portion of URL path)
     if (chunks[idx].toLowerCase() === 'dev') {
         idx++

--- a/src/morse/morse.ts
+++ b/src/morse/morse.ts
@@ -176,6 +176,9 @@ export class MorseViewModel {
 
     this.showRaw(false)
 
+	// attempt to load lesson based on current URL path
+    this.lessons.loadLessonFromPath(window.location.pathname)
+
     this.applyEnabled = ko.computed(() => {
       if (this.lessons && this.lessons.customGroup()) {
         return true

--- a/src/morse/morsePresetSetFinder.js
+++ b/src/morse/morsePresetSetFinder.js
@@ -6,14 +6,23 @@ export class MorsePresetSetFileFinder {
   static getMorsePresetSetFile = (fileName, afterFound) => {
     switch (fileName) {
       // BEGINA
-      case 'ADV.json':
-        import('../presets/sets/ADV.json').then(({ default: x }) => afterFound({ found: true, data: x }))
-        break
       case 'ADV1.json':
         import('../presets/sets/ADV1.json').then(({ default: x }) => afterFound({ found: true, data: x }))
         break
       case 'ADV2.json':
         import('../presets/sets/ADV2.json').then(({ default: x }) => afterFound({ found: true, data: x }))
+        break
+      case 'ADV3.json':
+        import('../presets/sets/ADV3.json').then(({ default: x }) => afterFound({ found: true, data: x }))
+        break
+      case 'INT1.json':
+        import('../presets/sets/INT1.json').then(({ default: x }) => afterFound({ found: true, data: x }))
+        break
+      case 'INT2.json':
+        import('../presets/sets/INT2.json').then(({ default: x }) => afterFound({ found: true, data: x }))
+        break
+      case 'INT3.json':
+        import('../presets/sets/INT3.json').then(({ default: x }) => afterFound({ found: true, data: x }))
         break
       case 'bc1.json':
         import('../presets/sets/bc1.json').then(({ default: x }) => afterFound({ found: true, data: x }))
@@ -23,15 +32,6 @@ export class MorsePresetSetFileFinder {
         break
       case 'bc3.json':
         import('../presets/sets/bc3.json').then(({ default: x }) => afterFound({ found: true, data: x }))
-        break
-      case 'int_12_16.json':
-        import('../presets/sets/int_12_16.json').then(({ default: x }) => afterFound({ found: true, data: x }))
-        break
-      case 'int_16_20.json':
-        import('../presets/sets/int_16_20.json').then(({ default: x }) => afterFound({ found: true, data: x }))
-        break
-      case 'int_1_12.json':
-        import('../presets/sets/int_1_12.json').then(({ default: x }) => afterFound({ found: true, data: x }))
         break
         // BEGINB
       default:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,8 @@ module.exports = {
     filename: '[name][contenthash].js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
-    assetModuleFilename: '[name][ext]'
+    assetModuleFilename: '[name][ext]',
+    publicPath: '/'
   },
   devServer: {
     static: {


### PR DESCRIPTION
## Description
As a student and now associate instructor, I feel we spend a lot of time walking folks through setting up the MPP. Why don't we provide links that can do most of the work for us and our students? This should help make for easy sharing during classes and in documents.

**URL Rules**:
* Don't worry about capitalization. Components of the path are converted to uppercase before compare.
* Spaces are represented as `_` characters.
* Some items need to be URL encoded. (_Example: `59,` should be `59%2C`_)
* Classes are normalize to the format `BC1`, `INT1`, `ADV1` to make things easier.

**Examples**:
(_Test these locally..._)
* http://localhost:3000/student/bc3/call_signs/callsigns_3-4_characters
* http://localhost:3000/student/bc2/qxv/b1_qxv
* http://localhost:3000/student/bc2/59%2C/b1_review
* http://localhost:3000/instructor/bc2/28bk/bk

## Testing
* Build: `npm run build`
* Run: `npm run dev`
* Navigate to http://localhost:3000 (_Note: this may differ on other OSes_)
* Try some of the example links

## Further Improvements
* Allow presets to be part of URL. (_Working on this now..._)
* Have UI element to create a link from your current place within MPP

de N4DXS - Shawn