### PR TITLE
fix(ci): bump main2.yml Node version from 12.x to 20.x

### DIFF
--- a/.github/workflows/main2.yml
+++ b/.github/workflows/main2.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
-          node-version: 12.x
+          node-version: 20.x
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- PR #257 (`develop` → `main`) is unblocked from its merge conflict (#258 merged), but its `build` check is now failing on Node 12.x in `.github/workflows/main2.yml` — the only CI workflow still pinned to that old version.
- Failure: `Cannot find module 'node:path'` during `npm run build` — `copy-webpack-plugin` uses the `node:`-prefixed core module import, which Node 12 can't resolve (needs ≥14.18, project already runs fine on 20.x elsewhere).
- `develop2.yml` already runs successfully on Node 20.x, so this bumps `main2.yml` to match.

## Test plan
- [x] Ran `npm ci && npm run build` locally with a modern Node version (22.x) — build completes with exit code 0
- [x] Confirmed only `.github/workflows/main2.yml` was changed (one line: `node-version: 12.x` → `20.x`)
- [ ] Confirm CI (`main2.yml`) passes on this PR
- [ ] Confirm PR #257's `build` check turns green once this merges into `develop`


---
_Generated by [Claude Code](https://claude.ai/code/session_014vbBkdH3EYko1LP1XwDkxh)_