### PR TITLE
fix(a11y): lesson pickers announce current value and selection

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -144,6 +144,7 @@ Guidelines:
 - Do not put timers or rapidly changing counts in live regions.
 - Use `aria-describedby` for helpful hidden context.
 - Give component controls meaningful names, especially experimental RSS and Noise controls.
+- Custom listbox/dropdown pickers (LICW Lessons TYPE/CLASS/CONTENT/LESSON/PRESETS) must expose **label + current value** on the toggle (`aria-labelledby` spanning both IDs) and **`aria-selected`** on each `role="option"`. Do not name the toggle from the field label alone.
 - Update `e2e/accessibility.spec.ts` when changing labels, descriptions, or live-region behavior.
 
 ## Lessons And Presets

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -24,6 +24,37 @@ test('initial page has accessible names for primary controls', async ({ page }) 
   await expect(page.locator('[role="status"][aria-live="polite"]')).toBeAttached()
   await expect(page.locator('[aria-live]')).toHaveCount(1)
 
+  const typeToggle = page.locator('#lessonsPickerTypeToggle')
+  await expect(typeToggle).toHaveAccessibleName(/TYPE.*STUDENT/i)
+  await expect(typeToggle).toHaveAttribute('aria-haspopup', 'listbox')
+
+  await expectNoAxeViolations(page)
+})
+
+test('lesson type picker exposes selected option to screen readers', async ({ page }) => {
+  await page.goto('/')
+
+  const typeToggle = page.locator('#lessonsPickerTypeToggle')
+  await expect(typeToggle).toHaveAccessibleName(/TYPE.*STUDENT/i)
+
+  await typeToggle.click()
+  await expect(typeToggle).toHaveAttribute('aria-expanded', 'true')
+
+  const curriculumList = page.getByRole('listbox', { name: 'Curriculum kind' })
+  const selected = curriculumList.getByRole('option', { selected: true })
+  await expect(selected).toHaveText('STUDENT')
+  await expect(selected).toHaveAttribute('aria-selected', 'true')
+
+  const instructor = curriculumList.getByRole('option', { name: 'INSTRUCTOR' })
+  await expect(instructor).toHaveAttribute('aria-selected', 'false')
+  await instructor.click()
+
+  await expect(typeToggle).toHaveAccessibleName(/TYPE.*INSTRUCTOR/i)
+  await expect(typeToggle).toBeFocused()
+
+  await typeToggle.click()
+  await expect(curriculumList.getByRole('option', { selected: true })).toHaveText('INSTRUCTOR')
+
   await expectNoAxeViolations(page)
 })
 

--- a/e2e/lesson-picker.spec.ts
+++ b/e2e/lesson-picker.spec.ts
@@ -1,22 +1,27 @@
 import { expect, test } from '@playwright/test'
 
-test('lesson dropdowns update selection labels', async ({ page }) => {
+test('lesson dropdowns update selection labels and accessible names', async ({ page }) => {
   await page.goto('/')
   const lessonsPanel = page.locator('#accordianItemLessonControls')
   await expect(lessonsPanel).toHaveClass(/show/)
 
-  const typeToggle = page.getByLabel('TYPE')
+  const typeToggle = page.locator('#lessonsPickerTypeToggle')
   await expect(typeToggle).toContainText('STUDENT')
+  await expect(typeToggle).toHaveAccessibleName(/TYPE.*STUDENT/i)
 
-  const classToggle = page.getByLabel('CLASS', { exact: true })
+  const classToggle = page.locator('#lessonsPickerClassToggle')
   await expect(classToggle).toBeEnabled()
   await classToggle.click()
   await page.getByLabel('Class').getByRole('option', { name: 'BC1' }).click()
   await expect(classToggle).toContainText('BC1')
+  await expect(classToggle).toHaveAccessibleName(/CLASS.*BC1/i)
+  await expect(classToggle).toBeFocused()
 
-  const contentToggle = page.getByLabel('CONTENT', { exact: true })
+  const contentToggle = page.locator('#lessonsPickerContentToggle')
   await expect(contentToggle).toBeEnabled()
   await contentToggle.click()
   await page.getByLabel('Content').getByRole('option', { name: 'REA' }).click()
   await expect(contentToggle).toContainText('REA')
+  await expect(contentToggle).toHaveAccessibleName(/CONTENT.*REA/i)
+  await expect(contentToggle).toBeFocused()
 })

--- a/src/morse/lessons/morseLessonPlugin.ts
+++ b/src/morse/lessons/morseLessonPlugin.ts
@@ -537,6 +537,12 @@ export default class MorseLessonPlugin implements ICookieHandler {
     }
   }
 
+  focusLessonPickerToggle = (toggleId: string) => {
+    window.setTimeout(() => {
+      document.getElementById(toggleId)?.focus({ preventScroll: true })
+    }, 0)
+  }
+
   changeUserTarget = (userTarget, fromClick = "") => {
     if (this.userTargetInitialized) {
       this.userTarget(userTarget)
@@ -545,6 +551,7 @@ export default class MorseLessonPlugin implements ICookieHandler {
       this.setPresetSelected(this.selectedSettingsPreset(), true)
       if (fromClick === 'click') {
         this.morseViewModel.announce?.(`Type selected: ${userTarget}`)
+        this.focusLessonPickerToggle('lessonsPickerTypeToggle')
       }
     }
   }
@@ -566,6 +573,7 @@ export default class MorseLessonPlugin implements ICookieHandler {
       this.upsertQueryStringVariable('selectedClass', selectedClass)
       if (fromClick === 'click') {
         this.morseViewModel.announce?.(`Class selected: ${selectedClass}`)
+        this.focusLessonPickerToggle('lessonsPickerClassToggle')
       }
     }
   }
@@ -587,15 +595,24 @@ export default class MorseLessonPlugin implements ICookieHandler {
       this.upsertQueryStringVariable('selectedGroup', letterGroup)
       if (fromClick === 'click') {
         this.morseViewModel.announce?.(`Content selected: ${letterGroup}`)
+        this.focusLessonPickerToggle('lessonsPickerContentToggle')
       }
     }
   }
 
+  /** Collapse LICW Lessons without focusing the accordion header (avoids SR focus jumps). */
   closeLessonAccordianIfAutoClosing = () => {
-    if (this.autoCloseLessonAccordion()) {
-      const elem = document.getElementById('lessonAccordianButton')
-      elem.click()
+    if (!this.autoCloseLessonAccordion()) {
+      return
     }
+    const panel = document.getElementById('accordianItemLessonControls')
+    const button = document.getElementById('lessonAccordianButton')
+    if (!panel?.classList.contains('show')) {
+      return
+    }
+    panel.classList.remove('show')
+    button?.classList.add('collapsed')
+    button?.setAttribute('aria-expanded', 'false')
   }
 
   setDisplaySelected = (display, skipPresets = false, fromClick="") => {
@@ -619,6 +636,7 @@ export default class MorseLessonPlugin implements ICookieHandler {
         }
         if (fromClick === 'click') {
           this.morseViewModel.announce?.(`Lesson selected: ${display.display}`)
+          this.focusLessonPickerToggle('lessonsPickerLessonToggle')
         }
       }
     }
@@ -646,6 +664,7 @@ export default class MorseLessonPlugin implements ICookieHandler {
       this.selectedSettingsPreset(preset)
       if (fromClick === 'click') {
         this.morseViewModel.announce?.(`Preset selected: ${preset.display}`)
+        this.focusLessonPickerToggle('lessonsPickerPresetsToggle')
       }
       const settingsInfo = new SettingsChangeInfo(this.morseViewModel)
       settingsInfo.ifLoadSettings = true

--- a/src/template.html
+++ b/src/template.html
@@ -150,14 +150,17 @@
                                         <span class="lessons-picker-label" id="lessonsPickerTypeLabel">TYPE</span>
                                         <div class="dropdown lessons-picker-dropdown">
                                             <button type="button" class="btn btn-outline-primary dropdown-toggle w-100"
+                                                id="lessonsPickerTypeToggle"
                                                 data-bs-toggle="dropdown" aria-expanded="false"
-                                                aria-labelledby="lessonsPickerTypeLabel"
-                                                data-bind="text: lessons.userTarget() || 'Select type'"></button>
+                                                aria-haspopup="listbox"
+                                                aria-labelledby="lessonsPickerTypeLabel lessonsPickerTypeValue">
+                                                <span id="lessonsPickerTypeValue" data-bind="text: lessons.userTarget() || 'Select type'"></span>
+                                            </button>
                                             <ul class="dropdown-menu w-100" role="listbox" aria-label="Curriculum kind"
                                                 data-bind="foreach: lessons.userTargets">
                                                 <li role="presentation">
                                                     <button type="button" role="option" class="dropdown-item"
-                                                        data-bind="text: $data, click: () => $root.lessons.changeUserTarget($data, 'click'), css: { active: $data === $root.lessons.userTarget() }"></button>
+                                                        data-bind="text: $data, click: () => $root.lessons.changeUserTarget($data, 'click'), css: { active: $data === $root.lessons.userTarget() }, attr: { 'aria-selected': $data === $root.lessons.userTarget() ? 'true' : 'false' }"></button>
                                                 </li>
                                             </ul>
                                         </div>
@@ -166,14 +169,18 @@
                                         <span class="lessons-picker-label" id="lessonsPickerClassLabel">CLASS</span>
                                         <div class="dropdown lessons-picker-dropdown">
                                             <button type="button" class="btn btn-outline-primary dropdown-toggle w-100"
+                                                id="lessonsPickerClassToggle"
                                                 data-bs-toggle="dropdown" aria-expanded="false"
-                                                aria-labelledby="lessonsPickerClassLabel"
-                                                data-bind="text: lessons.selectedClass() || 'Select class', enable: lessons.classes().length > 0"></button>
+                                                aria-haspopup="listbox"
+                                                aria-labelledby="lessonsPickerClassLabel lessonsPickerClassValue"
+                                                data-bind="enable: lessons.classes().length > 0">
+                                                <span id="lessonsPickerClassValue" data-bind="text: lessons.selectedClass() || 'Select class'"></span>
+                                            </button>
                                             <ul class="dropdown-menu w-100" role="listbox" aria-label="Class"
                                                 data-bind="foreach: lessons.classes">
                                                 <li role="presentation">
                                                     <button type="button" role="option" class="dropdown-item"
-                                                        data-bind="text: $data, click: () => $root.lessons.changeSelectedClass($data, 'click'), css: { active: $data === $root.lessons.selectedClass() }"></button>
+                                                        data-bind="text: $data, click: () => $root.lessons.changeSelectedClass($data, 'click'), css: { active: $data === $root.lessons.selectedClass() }, attr: { 'aria-selected': $data === $root.lessons.selectedClass() ? 'true' : 'false' }"></button>
                                                 </li>
                                             </ul>
                                         </div>
@@ -182,14 +189,18 @@
                                         <span class="lessons-picker-label" id="lessonsPickerContentLabel">CONTENT</span>
                                         <div class="dropdown lessons-picker-dropdown">
                                             <button type="button" class="btn btn-outline-primary dropdown-toggle w-100"
+                                                id="lessonsPickerContentToggle"
                                                 data-bs-toggle="dropdown" aria-expanded="false"
-                                                aria-labelledby="lessonsPickerContentLabel"
-                                                data-bind="text: lessons.letterGroup() || 'Select content', enable: lessons.letterGroups().length > 0"></button>
+                                                aria-haspopup="listbox"
+                                                aria-labelledby="lessonsPickerContentLabel lessonsPickerContentValue"
+                                                data-bind="enable: lessons.letterGroups().length > 0">
+                                                <span id="lessonsPickerContentValue" data-bind="text: lessons.letterGroup() || 'Select content'"></span>
+                                            </button>
                                             <ul class="dropdown-menu w-100" role="listbox" aria-label="Content"
                                                 data-bind="foreach: lessons.letterGroups">
                                                 <li role="presentation">
                                                     <button type="button" role="option" class="dropdown-item"
-                                                        data-bind="text: $data, click: () => $root.lessons.setLetterGroup($data, 'click'), css: { active: $data === $root.lessons.letterGroup() }"></button>
+                                                        data-bind="text: $data, click: () => $root.lessons.setLetterGroup($data, 'click'), css: { active: $data === $root.lessons.letterGroup() }, attr: { 'aria-selected': $data === $root.lessons.letterGroup() ? 'true' : 'false' }"></button>
                                                 </li>
                                             </ul>
                                         </div>
@@ -198,14 +209,18 @@
                                         <span class="lessons-picker-label" id="lessonsPickerLessonLabel">LESSON</span>
                                         <div class="dropdown lessons-picker-dropdown">
                                             <button type="button" class="btn btn-outline-primary dropdown-toggle w-100"
+                                                id="lessonsPickerLessonToggle"
                                                 data-bs-toggle="dropdown" aria-expanded="false"
-                                                aria-labelledby="lessonsPickerLessonLabel"
-                                                data-bind="text: lessons.selectedDisplay().display || 'Select lesson', enable: lessons.displays().length > 0 ? !lessons.displays()[0].isDummy : false"></button>
+                                                aria-haspopup="listbox"
+                                                aria-labelledby="lessonsPickerLessonLabel lessonsPickerLessonValue"
+                                                data-bind="enable: lessons.displays().length > 0 ? !lessons.displays()[0].isDummy : false">
+                                                <span id="lessonsPickerLessonValue" data-bind="text: lessons.selectedDisplay().display || 'Select lesson'"></span>
+                                            </button>
                                             <ul class="dropdown-menu w-100" role="listbox" aria-label="Lesson"
                                                 data-bind="foreach: lessons.displays">
                                                 <li role="presentation" data-bind="if: !$data.isDummy">
                                                     <button type="button" role="option" class="dropdown-item"
-                                                        data-bind="text: $data.display, click: () => $root.lessons.setDisplaySelected($data, false, 'click'), css: { active: $data.display === $root.lessons.selectedDisplay().display }"></button>
+                                                        data-bind="text: $data.display, click: () => $root.lessons.setDisplaySelected($data, false, 'click'), css: { active: $data.display === $root.lessons.selectedDisplay().display }, attr: { 'aria-selected': $data.display === $root.lessons.selectedDisplay().display ? 'true' : 'false' }"></button>
                                                 </li>
                                             </ul>
                                         </div>
@@ -214,14 +229,18 @@
                                         <span class="lessons-picker-label" id="lessonsPickerPresetsLabel">PRESETS</span>
                                         <div class="dropdown lessons-picker-dropdown">
                                             <button type="button" class="btn btn-outline-primary dropdown-toggle w-100"
+                                                id="lessonsPickerPresetsToggle"
                                                 data-bs-toggle="dropdown" aria-expanded="false"
-                                                aria-labelledby="lessonsPickerPresetsLabel"
-                                                data-bind="text: lessons.selectedSettingsPreset().display || 'Select preset', enable: allowSaveCookies && lessons.settingsPresets().length > 0"></button>
+                                                aria-haspopup="listbox"
+                                                aria-labelledby="lessonsPickerPresetsLabel lessonsPickerPresetsValue"
+                                                data-bind="enable: allowSaveCookies && lessons.settingsPresets().length > 0">
+                                                <span id="lessonsPickerPresetsValue" data-bind="text: lessons.selectedSettingsPreset().display || 'Select preset'"></span>
+                                            </button>
                                             <ul class="dropdown-menu w-100" role="listbox" aria-label="Settings preset"
                                                 data-bind="foreach: lessons.settingsPresets">
                                                 <li role="presentation">
                                                     <button type="button" role="option" id="btnLessonSettingsPresets" class="dropdown-item"
-                                                        data-bind="text: $data.display, enable: $root.allowSaveCookies, click: () => $root.lessons.setPresetSelected($data, false, 'click'), css: { active: $data.display === $root.lessons.selectedSettingsPreset().display }"></button>
+                                                        data-bind="text: $data.display, enable: $root.allowSaveCookies, click: () => $root.lessons.setPresetSelected($data, false, 'click'), css: { active: $data.display === $root.lessons.selectedSettingsPreset().display }, attr: { 'aria-selected': $data.display === $root.lessons.selectedSettingsPreset().display ? 'true' : 'false' }"></button>
                                                 </li>
                                             </ul>
                                         </div>

--- a/tests/unit/lessons/closeLessonAccordion.test.ts
+++ b/tests/unit/lessons/closeLessonAccordion.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/** Mirrors MorseLessonPlugin.closeLessonAccordianIfAutoClosing when auto-close is on */
+function closeLessonAccordianIfAutoClosing (autoCloseEnabled: boolean) {
+  if (!autoCloseEnabled) {
+    return
+  }
+  const panel = document.getElementById('accordianItemLessonControls')
+  const button = document.getElementById('lessonAccordianButton')
+  if (!panel?.classList.contains('show')) {
+    return
+  }
+  panel.classList.remove('show')
+  button?.classList.add('collapsed')
+  button?.setAttribute('aria-expanded', 'false')
+}
+
+describe('closeLessonAccordianIfAutoClosing', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="lessonAccordianButton" class="accordion-button" aria-expanded="true">LICW Lessons</button>
+      <div id="accordianItemLessonControls" class="accordion-collapse collapse show"></div>
+      <button id="lessonsPickerLessonToggle" type="button">Lesson</button>
+    `
+  })
+
+  it('collapses the lessons panel without focusing the accordion button', () => {
+    const accordionButton = document.getElementById('lessonAccordianButton') as HTMLButtonElement
+    const lessonToggle = document.getElementById('lessonsPickerLessonToggle') as HTMLButtonElement
+    const clickSpy = vi.spyOn(accordionButton, 'click')
+    lessonToggle.focus()
+
+    closeLessonAccordianIfAutoClosing(true)
+
+    expect(document.getElementById('accordianItemLessonControls')?.classList.contains('show')).toBe(false)
+    expect(accordionButton.classList.contains('collapsed')).toBe(true)
+    expect(accordionButton.getAttribute('aria-expanded')).toBe('false')
+    expect(clickSpy).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(lessonToggle)
+  })
+
+  it('does nothing when auto-close is off', () => {
+    closeLessonAccordianIfAutoClosing(false)
+    expect(document.getElementById('accordianItemLessonControls')?.classList.contains('show')).toBe(true)
+    expect(document.getElementById('lessonAccordianButton')?.getAttribute('aria-expanded')).toBe('true')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Screen-reader users were hearing only “TYPE, button, collapsed” after choosing Student/Instructor, because the Bootstrap dropdown conversion labeled toggles from the field name alone and never set `aria-selected` on options.

## Changes

- **Toggle accessible names**: each LICW Lessons picker (`TYPE` / `CLASS` / `CONTENT` / `LESSON` / `PRESETS`) uses `aria-labelledby` with both the field label and a value span, plus `aria-haspopup="listbox"`.
- **Selected options**: options set `aria-selected="true"|"false"` alongside the existing `.active` styling.
- **Focus**: Auto Close collapses the lessons accordion without programmatically clicking the header (which stole focus). After a picker selection, focus returns to that picker toggle.
- **Tests / docs**: Playwright coverage for accessible names, `aria-selected`, and focus restore; unit test for Auto Close collapse; developer guide note for custom listbox pickers.

## Manual check (for JAWS / NVDA / VoiceOver)

- Collapsed TYPE should announce current value (e.g. STUDENT / INSTRUCTOR).
- Expanded list should announce the selected option as selected.
- With Auto Close on, selecting a lesson should not jump focus to an unexpected control.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f721d-74b7-7478-bd13-65bd30e541ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f721d-74b7-7478-bd13-65bd30e541ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

