### PR TITLE
Fix OverLearn hyperlinks not applying preset speeds

### DIFF
--- a/docs/OVERLEARN_RICH_LINKS.md
+++ b/docs/OVERLEARN_RICH_LINKS.md
@@ -1,0 +1,73 @@
+# OverLearn Rich Links to MPP
+
+Tom-style deep links for the **OVERLEARN** class on the club Morse Practice Page.
+
+**Base URL:** `https://longislandcw.github.io/morsebrowser/index.html`
+
+Query shape: `?selectedClass=OVERLEARN&selectedGroup=…&selectedLesson=…&selectedPreset=…`
+
+All links below were validated against `wordlists.json` and `presets/sets/POL.json`.
+
+Speed notes:
+
+- **(31-27-23 WPM)** → preset `SPEED RACING 23wpm` (Speed Racer multipliers `1.348, 1.174, 1.0`)
+- **(23-27-31 WPM)** → preset `SPEED RACING - REVERSED 23wpm`
+- **(23-27-23 WPM)** → preset `SPEED RACING PEAK 23wpm`
+- **(WPM/FWPM)** e.g. `27/25` → Farnsworth spacing presets (`syncWpm` off)
+
+## Level INT1 & 2 Exercises
+
+- [Alphabet (23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2023wpm)
+- [Alphabet (27 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2027wpm)
+- [Alphabet (31 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2031wpm)
+- [Alphabet Mix #1 (23-27-31 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET%20MIX&selectedPreset=SPEED%20RACING%20-%20REVERSED%2023wpm) — _Speed Racer ascending_
+- [Alphabet Mix #2 (23-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET%20MIX&selectedPreset=SPEED%20RACING%20PEAK%2023wpm) — _Speed Racer peak (new preset)_
+- [Numbers (23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=NUMBERS&selectedPreset=CHARACTERS%2023wpm)
+- [Numbers (27 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=NUMBERS&selectedPreset=CHARACTERS%2027wpm)
+- [2 letter words – (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-3 letter words #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-3 letter words #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-3 letter words #3 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%203&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-3 letter words #4 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%204&selectedPreset=SPEED%20RACING%2023wpm)
+- [Many 3-Ltr words (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=MANY%203%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-word phrases #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-word phrases #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [2-word phrases #3 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%203&selectedPreset=SPEED%20RACING%2023wpm)
+- [Many 2-word phrases (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=MANY%202%20WORD&selectedPreset=SPEED%20RACING%2023wpm)
+- [States and Provinces – No Voice](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=STATE%20AND%20PROVINCES&selectedPreset=PHRASES%2FWORDS%203X%2023wpm) — _Speed not specified in list; used 23wpm 3X_
+- [States and Provinces – Voice](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=STATE%20AND%20PROVINCES&selectedPreset=VOICE%20AFTER%20WORDS%2023wpm) — _Speed not specified in list; used 23wpm voice-after_
+- [Sending: Letters (27)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20ALPHABET%201&selectedPreset=SENDING%20ALPHABET%2027wpm) — _Uses SENDING ALPHABET 1 (SENDING ALPHABET 2 also exists)_
+- [Sending: Numbers (27)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20NUMBERS%201&selectedPreset=SENDING%20NUMBERS%2027wpm) — _Uses SENDING NUMBERS 1_
+- [Sending Tri-Letters (27)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20TRI-LETTERS&selectedPreset=SENDING%20Tri-Letters%2027wpm)
+## Level INT2 & 3 Exercises
+
+- [3-4 letter words #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=3-4%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [3-4 letter words #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=3-4%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [4 letter words #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [4 letter words #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [Many 4-Ltr words (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=MANY%204%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm)
+- [4-5 letter words (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4-5%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm) — _PART 2 also exists if needed_
+- [Binomial Expressions #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=BINOMIALS&selectedLesson=BINOMIALS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [Binomial Expressions #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=BINOMIALS&selectedLesson=BINOMIALS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [Short phrases #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=SHORT%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [Short phrases #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=SHORT%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [Sending 3 to 5-letter words (27 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=3-5%20WORDS&selectedPreset=SENDING%20WORDS%2FPHRASES%2027wpm)
+- [Sending 5 to 7-letter words (27 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=5-7%20WORDS&selectedPreset=SENDING%20WORDS%2FPHRASES%2027wpm)
+## Level INT3 & ADV1 Exercises
+
+- [3-word phrases #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [3-word phrases #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [3-word phrases CW/Voice/CW (27/25 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20CW-VOICE-CW&selectedPreset=PHRASES%20CW-VOICE-CW%2027%2F25wpm) — _New Farnsworth preset_
+- [Sentences CW/Voice/CW (27/25 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2027%2F25wpm) — _New Farnsworth preset_
+- [Word length builder #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORD%20BUILDING&selectedLesson=WORD%20BUILDING%20BASIC&selectedPreset=SPEED%20RACING%2023wpm)
+- [Word length builder #2 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORD%20BUILDING&selectedLesson=WORD%20BUILDING%20INTERMEDIATE&selectedPreset=SPEED%20RACING%2023wpm) — _Renamed from INTERMEDIAT (trailing space removed)_
+- [5 letter words #1 (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=5%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm)
+- [5 letter words #2 (31-27-23)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=5%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm)
+- [ING suffix exercise #1 (31-27-23)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=ING&selectedPreset=SPEED%20RACING%2023wpm) — _Only one ING wordfile exists; #1 and #2 share content_
+- [ING suffix exercise #2 (31-27-23)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=ING&selectedPreset=SPEED%20RACING%2023wpm) — _Same content as #1 until a second ING part is added_
+- [Common suffixes (27)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=SUFFIXES%20ALL&selectedPreset=SUFFIXES%2027wpm)
+- [Top 100 words (31-27-23 WPM)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=TOP%20100%20WORDS&selectedPreset=SPEED%20RACING%2023wpm)
+- [Top 100 word sentences – CW/Voice/CW – (23/21)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2023%2F21wpm) — _New Farnsworth preset_
+- [Top 100 word sentences – CW/Voice/CW – (27/25)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2027%2F25wpm) — _New Farnsworth preset_
+- [Top 100 word sentences – CW/Voice/CW – (31/28)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2031%2F28wpm) — _New Farnsworth preset_
+- [One-Liner Jokes – CW/Voice/CW (23/21)](https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=JOKES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2023%2F21wpm) — _New Farnsworth preset_

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Developer and maintainer documentation for the LICW Morse Practice Page source t
 |----------|-----|
 | [DEVELOPER_GUIDE.md](./DEVELOPER_GUIDE.md) | Architecture, UI layout, build flow, lessons/presets, playback, deployment, tests |
 | [SPEED_RACER.md](./SPEED_RACER.md) | Speed Racer UI, playback behavior, preset keys, Tom-style deep links |
+| [OVERLEARN_RICH_LINKS.md](./OVERLEARN_RICH_LINKS.md) | Tom’s OverLearn exercise deep links (also [HTML](./overlearn-rich-links.html)) |
 | [../tests/README.md](../tests/README.md) | Vitest, Playwright, accessibility E2E, CI notes |
 | [../MAINTAINERS.md](../MAINTAINERS.md) | Maintainer checklist and source map |
 | [../AGENTS.md](../AGENTS.md) | Fork-specific agent notes and Roger's workflow preferences |

--- a/docs/overlearn-rich-links.html
+++ b/docs/overlearn-rich-links.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>OverLearn Rich Links to MPP</title>
+<style>
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 52rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.45; color: #1a1a1a; }
+  h1 { font-size: 1.6rem; }
+  h2 { font-size: 1.25rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .25rem; }
+  ol { padding-left: 1.4rem; }
+  li { margin: .45rem 0; }
+  a { color: #0b57d0; }
+  .meta { color: #444; font-size: .95rem; }
+  .note { color: #666; font-size: .85rem; }
+  code { font-size: .85em; }
+</style>
+</head>
+<body>
+<h1>OverLearn Rich Links to MPP</h1>
+<p class="meta">Club MPP deep links for Tom’s OverLearn exercise list. Each link loads OVERLEARN class, content, lesson, and preset (including speeds).</p>
+<p class="meta">Base: <code>https://longislandcw.github.io/morsebrowser/index.html</code></p>
+<h2>Level INT1 & 2 Exercises</h2>
+<ol>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2023wpm">Alphabet (23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2027wpm">Alphabet (27 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2031wpm">Alphabet (31 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET%20MIX&selectedPreset=SPEED%20RACING%20-%20REVERSED%2023wpm">Alphabet Mix #1 (23-27-31 WPM)</a> <span class="note">(Speed Racer ascending)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET%20MIX&selectedPreset=SPEED%20RACING%20PEAK%2023wpm">Alphabet Mix #2 (23-27-23 WPM)</a> <span class="note">(Speed Racer peak (new preset))</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=NUMBERS&selectedPreset=CHARACTERS%2023wpm">Numbers (23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=NUMBERS&selectedPreset=CHARACTERS%2027wpm">Numbers (27 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm">2 letter words – (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">2-3 letter words #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">2-3 letter words #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%203&selectedPreset=SPEED%20RACING%2023wpm">2-3 letter words #3 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%204&selectedPreset=SPEED%20RACING%2023wpm">2-3 letter words #4 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=MANY%203%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm">Many 3-Ltr words (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">2-word phrases #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">2-word phrases #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%203&selectedPreset=SPEED%20RACING%2023wpm">2-word phrases #3 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=MANY%202%20WORD&selectedPreset=SPEED%20RACING%2023wpm">Many 2-word phrases (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=STATE%20AND%20PROVINCES&selectedPreset=PHRASES%2FWORDS%203X%2023wpm">States and Provinces – No Voice</a> <span class="note">(Speed not specified in list; used 23wpm 3X)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=STATE%20AND%20PROVINCES&selectedPreset=VOICE%20AFTER%20WORDS%2023wpm">States and Provinces – Voice</a> <span class="note">(Speed not specified in list; used 23wpm voice-after)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20ALPHABET%201&selectedPreset=SENDING%20ALPHABET%2027wpm">Sending: Letters (27)</a> <span class="note">(Uses SENDING ALPHABET 1 (SENDING ALPHABET 2 also exists))</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20NUMBERS%201&selectedPreset=SENDING%20NUMBERS%2027wpm">Sending: Numbers (27)</a> <span class="note">(Uses SENDING NUMBERS 1)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20TRI-LETTERS&selectedPreset=SENDING%20Tri-Letters%2027wpm">Sending Tri-Letters (27)</a></li>
+</ol>
+<h2>Level INT2 & 3 Exercises</h2>
+<ol>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=3-4%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">3-4 letter words #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=3-4%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">3-4 letter words #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">4 letter words #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">4 letter words #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=MANY%204%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm">Many 4-Ltr words (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4-5%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">4-5 letter words (31-27-23 WPM)</a> <span class="note">(PART 2 also exists if needed)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=BINOMIALS&selectedLesson=BINOMIALS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">Binomial Expressions #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=BINOMIALS&selectedLesson=BINOMIALS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">Binomial Expressions #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=SHORT%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">Short phrases #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=SHORT%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">Short phrases #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=3-5%20WORDS&selectedPreset=SENDING%20WORDS%2FPHRASES%2027wpm">Sending 3 to 5-letter words (27 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=5-7%20WORDS&selectedPreset=SENDING%20WORDS%2FPHRASES%2027wpm">Sending 5 to 7-letter words (27 WPM)</a></li>
+</ol>
+<h2>Level INT3 & ADV1 Exercises</h2>
+<ol>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">3-word phrases #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">3-word phrases #2 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20CW-VOICE-CW&selectedPreset=PHRASES%20CW-VOICE-CW%2027%2F25wpm">3-word phrases CW/Voice/CW (27/25 WPM)</a> <span class="note">(New Farnsworth preset)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2027%2F25wpm">Sentences CW/Voice/CW (27/25 WPM)</a> <span class="note">(New Farnsworth preset)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORD%20BUILDING&selectedLesson=WORD%20BUILDING%20BASIC&selectedPreset=SPEED%20RACING%2023wpm">Word length builder #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORD%20BUILDING&selectedLesson=WORD%20BUILDING%20INTERMEDIATE&selectedPreset=SPEED%20RACING%2023wpm">Word length builder #2 (31-27-23 WPM)</a> <span class="note">(Renamed from INTERMEDIAT (trailing space removed))</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=5%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm">5 letter words #1 (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=5%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm">5 letter words #2 (31-27-23)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=ING&selectedPreset=SPEED%20RACING%2023wpm">ING suffix exercise #1 (31-27-23)</a> <span class="note">(Only one ING wordfile exists; #1 and #2 share content)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=ING&selectedPreset=SPEED%20RACING%2023wpm">ING suffix exercise #2 (31-27-23)</a> <span class="note">(Same content as #1 until a second ING part is added)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=SUFFIXES%20ALL&selectedPreset=SUFFIXES%2027wpm">Common suffixes (27)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=TOP%20100%20WORDS&selectedPreset=SPEED%20RACING%2023wpm">Top 100 words (31-27-23 WPM)</a></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2023%2F21wpm">Top 100 word sentences – CW/Voice/CW – (23/21)</a> <span class="note">(New Farnsworth preset)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2027%2F25wpm">Top 100 word sentences – CW/Voice/CW – (27/25)</a> <span class="note">(New Farnsworth preset)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2031%2F28wpm">Top 100 word sentences – CW/Voice/CW – (31/28)</a> <span class="note">(New Farnsworth preset)</span></li>
+<li><a href="https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=JOKES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2023%2F21wpm">One-Liner Jokes – CW/Voice/CW (23/21)</a> <span class="note">(New Farnsworth preset)</span></li>
+</ol>
+<h2>Mapping reference</h2>
+<ul>
+<li><strong>31-27-23</strong> → SPEED RACING 23wpm</li>
+<li><strong>23-27-31</strong> → SPEED RACING - REVERSED 23wpm</li>
+<li><strong>23-27-23</strong> → SPEED RACING PEAK 23wpm</li>
+<li><strong>WPM/FWPM</strong> (e.g. 27/25) → Farnsworth preset with syncWpm off</li>
+</ul>
+</body>
+</html>

--- a/src/morse/lessons/morseLessonPlugin.ts
+++ b/src/morse/lessons/morseLessonPlugin.ts
@@ -272,12 +272,43 @@ export default class MorseLessonPlugin implements ICookieHandler {
 
   }
 
+  /**
+   * Apply selectedPreset from the query string once that display name exists in
+   * settingsPresets. Returns true when a matching preset was selected.
+   *
+   * Deep-link init can call setSettingsPresetsInitialized before the async
+   * preset-set file finishes loading; callers must retry after the list updates.
+   */
+  applyPresetFromQueryString = (): boolean => {
+    const paramPreset = GeneralUtils.getParameterByName('selectedPreset')
+    if (!paramPreset || !this.settingsPresetsInitialized) {
+      return false
+    }
+    const target = this.settingsPresets().find(c => c.display.toUpperCase() === paramPreset.toUpperCase())
+    if (!target) {
+      return false
+    }
+    this.setPresetSelected(target)
+    if (!this.queryStringSettingsOn) {
+      // Match prior behavior: strip after apply so a late competing select cannot
+      // see a stale selectedPreset and skip (see setPresetSelected guard).
+      setTimeout(() => {
+        this.removeQueryStringVariable('selectedPreset')
+      }, 1000)
+    }
+    return true
+  }
+
   getSettingsPresets = (forceRefresh:boolean = false, selectFirstNonYour:boolean = false) => {
     let sps:SettingsOption[] = []
     sps.push(this.yourSettingsDummy)
     sps = sps.concat(this.customSettingsOptions)
 
     const handleAutoSelect = () => {
+      // Prefer Tom-style ?selectedPreset= once the set list is available.
+      if (this.applyPresetFromQueryString()) {
+        return
+      }
       if (selectFirstNonYour) {
         // console.log(`length:${this.settingsPresets().length}`)
         if (this.settingsPresets().length > 1) {
@@ -517,22 +548,12 @@ export default class MorseLessonPlugin implements ICookieHandler {
   setSettingsPresetsInitialized = () => {
     this.settingsPresetsInitialized = true
     if (GeneralUtils.getParameterByName('selectedPreset')) {
-      const paramClass = GeneralUtils.getParameterByName('selectedPreset').toUpperCase()
-      const targetClass = this.settingsPresets().find(c => c.display.toUpperCase() === paramClass)
-      if (targetClass) {
-        //console.log(`setting preset to ${targetClass.display}`)
-        // console.log(targetClass)
-        this.setPresetSelected(targetClass)
-        if (!this.queryStringSettingsOn) {
-          // not sure why delay here is needed but something is causing it to go to default if we don't.
-          // after a delay of 1 second remove selectedPreset from the Querystring now that we're done
-          setTimeout(() => {
-            this.removeQueryStringVariable('selectedPreset')
-          }, 1000)
+      if (!this.applyPresetFromQueryString()) {
+        // Preset-set file may still be loading; getSettingsPresets handleData retries.
+        // Log only when the list already has real options and still no match.
+        if (this.settingsPresets().length > 1) {
+          console.log('no preset found')
         }
-      } else {
-        console.log('no preset found')
-        
       }
     }
   }
@@ -777,6 +798,16 @@ export default class MorseLessonPlugin implements ICookieHandler {
   ensureSettingsPresetsInitialized = () => {
     if (!this.settingsPresetsInitialized) {
       this.setSettingsPresetsInitialized()
+      return
+    }
+    // Retry deep-link preset after async preset-set load (init often runs too early).
+    const paramPreset = GeneralUtils.getParameterByName('selectedPreset')
+    if (!paramPreset) {
+      return
+    }
+    const selected = this.selectedSettingsPreset()
+    if (selected?.isDummy || selected?.display?.toUpperCase() !== paramPreset.toUpperCase()) {
+      this.applyPresetFromQueryString()
     }
   }
 

--- a/src/presets/configs/POL_Random_1x_CVC_27_25.json
+++ b/src/presets/configs/POL_Random_1x_CVC_27_25.json
@@ -1,0 +1,184 @@
+{
+	"morseSettings": [
+		{
+			"key": "wpm",
+			"value": 27,
+			"comment": null
+		},
+		{
+			"key": "fwpm",
+			"value": 25,
+			"comment": null
+		},
+		{
+			"key": "xtraWordSpaceDits",
+			"value": "1",
+			"comment": null
+		},
+		{
+			"key": "volume",
+			"value": "10",
+			"comment": null
+		},
+		{
+			"key": "stickySets",
+			"value": "BK",
+			"comment": null
+		},
+		{
+			"key": "ifStickySets",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncWpm",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "hideList",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "showRaw",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "autoCloseLessonAccordian",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "customGroup",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "showExpertSettings",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "voiceEnabled",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "voiceSpelling",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceThinkingTime",
+			"value": "1.25",
+			"comment": null
+		},
+		{
+			"key": "voiceAfterThinkingTime",
+			"value": "0",
+			"comment": null
+		},
+		{
+			"key": "voiceVolume",
+			"value": 10,
+			"comment": null
+		},
+		{
+			"key": "voiceLastOnly",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceRecap",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speakFirst",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "numberOfRepeats",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "speakFirstAdditionalWordspaces",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "keepLines",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMin",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMax",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "cardSpace",
+			"value": "1",
+			"comment": "AKA cardWait"
+		},
+		{
+			"key": "miscSettingsAccordionOpen",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "speedInterval",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "intervalTimingsText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalWpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalFwpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "voiceBufferMaxLength",
+			"value": 1,
+			"comment": null
+		},
+		{
+			"key": "isShuffledSet",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "shuffleIntraGroup",
+			"value": false,
+			"comment": null
+		}
+	]
+}

--- a/src/presets/configs/POL_Random_Sen_1x_CVC_23_21.json
+++ b/src/presets/configs/POL_Random_Sen_1x_CVC_23_21.json
@@ -1,0 +1,184 @@
+{
+	"morseSettings": [
+		{
+			"key": "wpm",
+			"value": 23,
+			"comment": null
+		},
+		{
+			"key": "fwpm",
+			"value": 21,
+			"comment": null
+		},
+		{
+			"key": "xtraWordSpaceDits",
+			"value": "1",
+			"comment": null
+		},
+		{
+			"key": "volume",
+			"value": "10",
+			"comment": null
+		},
+		{
+			"key": "stickySets",
+			"value": "BK",
+			"comment": null
+		},
+		{
+			"key": "ifStickySets",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncWpm",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "hideList",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "showRaw",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "autoCloseLessonAccordian",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "customGroup",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "showExpertSettings",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "voiceEnabled",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "voiceSpelling",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceThinkingTime",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "voiceAfterThinkingTime",
+			"value": "0",
+			"comment": null
+		},
+		{
+			"key": "voiceVolume",
+			"value": 10,
+			"comment": null
+		},
+		{
+			"key": "voiceLastOnly",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceRecap",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speakFirst",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "numberOfRepeats",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "speakFirstAdditionalWordspaces",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "keepLines",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMin",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMax",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "cardSpace",
+			"value": "1",
+			"comment": "AKA cardWait"
+		},
+		{
+			"key": "miscSettingsAccordionOpen",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "speedInterval",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "intervalTimingsText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalWpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalFwpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "voiceBufferMaxLength",
+			"value": 1,
+			"comment": null
+		},
+		{
+			"key": "isShuffledSet",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "shuffleIntraGroup",
+			"value": false,
+			"comment": null
+		}
+	]
+}

--- a/src/presets/configs/POL_Random_Sen_1x_CVC_27_25.json
+++ b/src/presets/configs/POL_Random_Sen_1x_CVC_27_25.json
@@ -1,0 +1,184 @@
+{
+	"morseSettings": [
+		{
+			"key": "wpm",
+			"value": 27,
+			"comment": null
+		},
+		{
+			"key": "fwpm",
+			"value": 25,
+			"comment": null
+		},
+		{
+			"key": "xtraWordSpaceDits",
+			"value": "1",
+			"comment": null
+		},
+		{
+			"key": "volume",
+			"value": "10",
+			"comment": null
+		},
+		{
+			"key": "stickySets",
+			"value": "BK",
+			"comment": null
+		},
+		{
+			"key": "ifStickySets",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncWpm",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "hideList",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "showRaw",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "autoCloseLessonAccordian",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "customGroup",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "showExpertSettings",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "voiceEnabled",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "voiceSpelling",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceThinkingTime",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "voiceAfterThinkingTime",
+			"value": "0",
+			"comment": null
+		},
+		{
+			"key": "voiceVolume",
+			"value": 10,
+			"comment": null
+		},
+		{
+			"key": "voiceLastOnly",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceRecap",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speakFirst",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "numberOfRepeats",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "speakFirstAdditionalWordspaces",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "keepLines",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMin",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMax",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "cardSpace",
+			"value": "1",
+			"comment": "AKA cardWait"
+		},
+		{
+			"key": "miscSettingsAccordionOpen",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "speedInterval",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "intervalTimingsText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalWpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalFwpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "voiceBufferMaxLength",
+			"value": 1,
+			"comment": null
+		},
+		{
+			"key": "isShuffledSet",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "shuffleIntraGroup",
+			"value": false,
+			"comment": null
+		}
+	]
+}

--- a/src/presets/configs/POL_Random_Sen_1x_CVC_31_28.json
+++ b/src/presets/configs/POL_Random_Sen_1x_CVC_31_28.json
@@ -1,0 +1,184 @@
+{
+	"morseSettings": [
+		{
+			"key": "wpm",
+			"value": 31,
+			"comment": null
+		},
+		{
+			"key": "fwpm",
+			"value": 28,
+			"comment": null
+		},
+		{
+			"key": "xtraWordSpaceDits",
+			"value": "1",
+			"comment": null
+		},
+		{
+			"key": "volume",
+			"value": "10",
+			"comment": null
+		},
+		{
+			"key": "stickySets",
+			"value": "BK",
+			"comment": null
+		},
+		{
+			"key": "ifStickySets",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncWpm",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "hideList",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "showRaw",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "autoCloseLessonAccordian",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "customGroup",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "showExpertSettings",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "voiceEnabled",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "voiceSpelling",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceThinkingTime",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "voiceAfterThinkingTime",
+			"value": "0",
+			"comment": null
+		},
+		{
+			"key": "voiceVolume",
+			"value": 10,
+			"comment": null
+		},
+		{
+			"key": "voiceLastOnly",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceRecap",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speakFirst",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "numberOfRepeats",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "speakFirstAdditionalWordspaces",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "keepLines",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMin",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMax",
+			"value": "2",
+			"comment": null
+		},
+		{
+			"key": "cardSpace",
+			"value": "1",
+			"comment": "AKA cardWait"
+		},
+		{
+			"key": "miscSettingsAccordionOpen",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "speedInterval",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "intervalTimingsText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalWpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalFwpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "voiceBufferMaxLength",
+			"value": 1,
+			"comment": null
+		},
+		{
+			"key": "isShuffledSet",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "shuffleIntraGroup",
+			"value": false,
+			"comment": null
+		}
+	]
+}

--- a/src/presets/configs/POL_SR_PEAK_23.json
+++ b/src/presets/configs/POL_SR_PEAK_23.json
@@ -1,0 +1,224 @@
+{
+	"morseSettings": [
+		{
+			"key": "wpm",
+			"value": 23,
+			"comment": null
+		},
+		{
+			"key": "fwpm",
+			"value": 23,
+			"comment": null
+		},
+		{
+			"key": "xtraWordSpaceDits",
+			"value": "1",
+			"comment": null
+		},
+		{
+			"key": "volume",
+			"value": "4",
+			"comment": null
+		},
+		{
+			"key": "stickySets",
+			"value": "BK",
+			"comment": null
+		},
+		{
+			"key": "ifStickySets",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "syncWpm",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "hideList",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "showRaw",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "darkMode",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "autoCloseSettingsAccordions",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "autoCloseLessonAccordian",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "ifCustomGroup",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "customGroup",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "showExpertSettings",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "voiceEnabled",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceSpelling",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceThinkingTime",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "voiceAfterThinkingTime",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "voiceVolume",
+			"value": 10,
+			"comment": null
+		},
+		{
+			"key": "voiceLastOnly",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "voiceRecap",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speakFirst",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "numberOfRepeats",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "speakFirstAdditionalWordspaces",
+			"value": 0,
+			"comment": null
+		},
+		{
+			"key": "keepLines",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "syncSize",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "overrideSize",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMin",
+			"value": 3,
+			"comment": null
+		},
+		{
+			"key": "overrideSizeMax",
+			"value": 3,
+			"comment": null
+		},
+		{
+			"key": "cardSpace",
+			"value": 2,
+			"comment": "AKA cardWait"
+		},
+		{
+			"key": "miscSettingsAccordionOpen",
+			"value": "true",
+			"comment": null
+		},
+		{
+			"key": "speedInterval",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "intervalTimingsText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalWpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "intervalFwpmText",
+			"value": "",
+			"comment": null
+		},
+		{
+			"key": "speedRacerEnabled",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "speedRacerMultipliers",
+			"value": "1.0, 1.174, 1.0",
+			"comment": null
+		},
+		{
+			"key": "speedRacerFinalPlay",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speedRacerSpeakBeforeReplay",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "speedRacerKeepFwpm",
+			"value": true,
+			"comment": null
+		},
+		{
+			"key": "voiceBufferMaxLength",
+			"value": 1,
+			"comment": null
+		},
+		{
+			"key": "isShuffledSet",
+			"value": false,
+			"comment": null
+		},
+		{
+			"key": "shuffleIntraGroup",
+			"value": false,
+			"comment": null
+		}
+	]
+}

--- a/src/presets/sets/POL.json
+++ b/src/presets/sets/POL.json
@@ -1,18 +1,17 @@
 {
     "options": [
-
-       {
+        {
             "display": "BINOMIALS 23wpm",
             "filename": "POL_Random_3x_23.json"
-        }, 
-       {
+        },
+        {
             "display": "BINOMIALS 27wpm",
             "filename": "POL_Random_3x_27.json"
-        }, 
+        },
         {
             "display": "BINOMIALS 31wpm",
             "filename": "POL_Random_3x_31.json"
-        }, 
+        },
         {
             "display": "CHARACTERS 23wpm",
             "filename": "POL_Random_23.json"
@@ -21,46 +20,46 @@
             "display": "CHARACTERS 27wpm",
             "filename": "POL_Random_27.json"
         },
-         {
+        {
             "display": "CHARACTERS 31wpm",
             "filename": "POL_Random_31.json"
         },
         {
             "display": "PHRASES/WORDS 2X 23wpm",
             "filename": "POL_Random_2x_23.json"
-        }, 
+        },
         {
             "display": "PHRASES/WORDS 2X 27wpm",
             "filename": "POL_Random_2x_27.json"
-        }, 
-         {
+        },
+        {
             "display": "PHRASES/WORDS 2X 31wpm",
             "filename": "POL_Random_2x_31.json"
-        }, 
+        },
         {
             "display": "PHRASES/WORDS 3X 23wpm",
             "filename": "POL_Random_3x_23.json"
-        }, 
+        },
         {
             "display": "PHRASES/WORDS 3X 27wpm",
             "filename": "POL_Random_3x_27.json"
-        }, 
-         {
+        },
+        {
             "display": "PHRASES/WORDS 3X 31wpm",
             "filename": "POL_Random_3x_31.json"
-        }, 
+        },
         {
             "display": "PHRASES CW-VOICE-CW 23wpm",
             "filename": "POL_Random_1x_CVC_23.json"
-        }, 
+        },
         {
             "display": "PHRASES CW-VOICE-CW 27wpm",
             "filename": "POL_Random_1x_CVC_27.json"
-        }, 
-         {
+        },
+        {
             "display": "PHRASES CW-VOICE-CW 31wpm",
             "filename": "POL_Random_1x_CVC_31.json"
-        }, 
+        },
         {
             "display": "SENDING ALPHABET 23wpm",
             "filename": "POL_23_SA.json"
@@ -100,78 +99,94 @@
         {
             "display": "SENDING WORDS/PHRASES 31wpm",
             "filename": "POL_Random_1x_VCS_31.json"
-        },               
-       {
+        },
+        {
             "display": "SENTENCES CW 23wpm",
             "filename": "POL_Random_Sen_1x_C_23.json"
         },
-       {
+        {
             "display": "SENTENCES CW 27wpm",
             "filename": "POL_Random_Sen_1x_C_27.json"
         },
-       {
+        {
             "display": "SENTENCES CW 31wpm",
             "filename": "POL_Random_Sen_1x_C_31.json"
         },
-       {
+        {
             "display": "SENTENCES CW-VOICE 23wpm",
             "filename": "POL_Random_Sen_1x_CV_23.json"
         },
-       {
+        {
             "display": "SENTENCES CW-VOICE 27wpm",
             "filename": "POL_Random_Sen_1x_CV_27.json"
         },
-       {
+        {
             "display": "SENTENCES CW-VOICE 31wpm",
             "filename": "POL_Random_Sen_1x_CV_31.json"
-        }, 
-       {
+        },
+        {
             "display": "SENTENCES CW-VOICE-CW 23wpm",
             "filename": "POL_Random_Sen_1x_CVC_23.json"
-        },  
+        },
         {
             "display": "SENTENCES CW-VOICE-CW 27wpm",
             "filename": "POL_Random_Sen_1x_CVC_27.json"
-        },  
-         {
+        },
+        {
             "display": "SENTENCES CW-VOICE-CW 31wpm",
             "filename": "POL_Random_Sen_1x_CVC_31.json"
         },
-         {
+        {
             "display": "SPEED RACING 23wpm",
             "filename": "POL_SR_23.json"
-        },  
-         {
+        },
+        {
             "display": "SPEED RACING - REVERSED 23wpm",
             "filename": "POL_SR_REV_23.json"
-        }, 
-         {
+        },
+        {
             "display": "SUFFIXES 23wpm",
             "filename": "POL_Random_3x_23.json"
-        },  
+        },
         {
             "display": "SUFFIXES 27wpm",
             "filename": "POL_Random_3x_27.json"
-        },  
-         {
+        },
+        {
             "display": "SUFFIXES 31wpm",
             "filename": "POL_Random_3x_31.json"
         },
         {
             "display": "VOICE AFTER WORDS 23wpm",
             "filename": "POL_VA_Random_3x_23.json"
-        }, 
+        },
         {
             "display": "VOICE AFTER WORDS 27wpm",
             "filename": "POL_VA_Random_3x_27.json"
-        }, 
-         {
+        },
+        {
             "display": "VOICE AFTER WORDS 31wpm",
             "filename": "POL_VA_Random_3x_31.json"
-        }   
-
+        },
+        {
+            "display": "SPEED RACING PEAK 23wpm",
+            "filename": "POL_SR_PEAK_23.json"
+        },
+        {
+            "display": "PHRASES CW-VOICE-CW 27/25wpm",
+            "filename": "POL_Random_1x_CVC_27_25.json"
+        },
+        {
+            "display": "SENTENCES CW-VOICE-CW 23/21wpm",
+            "filename": "POL_Random_Sen_1x_CVC_23_21.json"
+        },
+        {
+            "display": "SENTENCES CW-VOICE-CW 27/25wpm",
+            "filename": "POL_Random_Sen_1x_CVC_27_25.json"
+        },
+        {
+            "display": "SENTENCES CW-VOICE-CW 31/28wpm",
+            "filename": "POL_Random_Sen_1x_CVC_31_28.json"
+        }
     ]
 }
-
-
-

--- a/src/wordfilesconfigs/wordlists.json
+++ b/src/wordfilesconfigs/wordlists.json
@@ -975,7 +975,7 @@
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "4 LETTER WORDS PART 2","fileName": "POL_4W_Pt2.txt"},
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "4 LETTER WORDS PART 3","fileName": "POL_4W_Pt3.txt"},
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "MANY 4 LETTER WORDS","fileName": "POL_4L_Words_Long.txt"},   
-{"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "4-5  LETTER WORDS PART 1","fileName": "POL_4-5W_Pt1.txt"},
+{"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "4-5 LETTER WORDS PART 1","fileName": "POL_4-5W_Pt1.txt"},
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "4-5 LETTER WORDS PART 2","fileName": "POL_4-5W_Pt2.txt"},       
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "5 LETTER WORDS PART 1","fileName": "POL_5W_Pt1.txt"},
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORDS","newlineChunking": false,"display": "5 LETTER WORDS PART 2","fileName": "POL_5W_Pt2.txt"},
@@ -985,7 +985,7 @@
 
 
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORD BUILDING","newlineChunking": false,"display": "WORD BUILDING BASIC","fileName": "POL_WB_Pt1.txt"},
-{"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORD BUILDING","newlineChunking": false,"display": "WORD BUILDING INTERMEDIAT ","fileName": "POL_WB_Pt2.txt"},
+{"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORD BUILDING","newlineChunking": false,"display": "WORD BUILDING INTERMEDIATE","fileName": "POL_WB_Pt2.txt"},
 {"sort": 529,"userTarget": "STUDENT","class": "OVERLEARN","letterGroup": "WORD BUILDING","newlineChunking": false,"display": "WORD BUILDING ADVANCED","fileName": "POL_WB_Pt3.txt"}
       
 ]}

--- a/tests/fixtures/overlearnRichLinks.json
+++ b/tests/fixtures/overlearnRichLinks.json
@@ -1,0 +1,502 @@
+[
+  {
+    "label": "Alphabet (23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "ALPHABET",
+    "preset": "CHARACTERS 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Alphabet (27 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "ALPHABET",
+    "preset": "CHARACTERS 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2027wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Alphabet (31 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "ALPHABET",
+    "preset": "CHARACTERS 31wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2031wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Alphabet Mix #1 (23-27-31 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "ALPHABET MIX",
+    "preset": "SPEED RACING - REVERSED 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET%20MIX&selectedPreset=SPEED%20RACING%20-%20REVERSED%2023wpm",
+    "ok": true,
+    "notes": "Speed Racer ascending"
+  },
+  {
+    "label": "Alphabet Mix #2 (23-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "ALPHABET MIX",
+    "preset": "SPEED RACING PEAK 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET%20MIX&selectedPreset=SPEED%20RACING%20PEAK%2023wpm",
+    "ok": true,
+    "notes": "Speed Racer peak (new preset)"
+  },
+  {
+    "label": "Numbers (23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "NUMBERS",
+    "preset": "CHARACTERS 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=NUMBERS&selectedPreset=CHARACTERS%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Numbers (27 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "CHARACTERS",
+    "lesson": "NUMBERS",
+    "preset": "CHARACTERS 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=NUMBERS&selectedPreset=CHARACTERS%2027wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2 letter words \u2013 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "2 LETTER WORDS",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-3 letter words #1 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "2-3 LETTER WORDS PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-3 letter words #2 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "2-3 LETTER WORDS PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-3 letter words #3 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "2-3 LETTER WORDS PART 3",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%203&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-3 letter words #4 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "2-3 LETTER WORDS PART 4",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=2-3%20LETTER%20WORDS%20PART%204&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Many 3-Ltr words (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "MANY 3 LETTER WORDS",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=MANY%203%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-word phrases #1 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "PHRASES",
+    "lesson": "2 WORD PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-word phrases #2 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "PHRASES",
+    "lesson": "2 WORD PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "2-word phrases #3 (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "PHRASES",
+    "lesson": "2 WORD PART 3",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=2%20WORD%20PART%203&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Many 2-word phrases (31-27-23 WPM)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "PHRASES",
+    "lesson": "MANY 2 WORD",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=MANY%202%20WORD&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "States and Provinces \u2013 No Voice",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "STATE AND PROVINCES",
+    "preset": "PHRASES/WORDS 3X 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=STATE%20AND%20PROVINCES&selectedPreset=PHRASES%2FWORDS%203X%2023wpm",
+    "ok": true,
+    "notes": "Speed not specified in list; used 23wpm 3X"
+  },
+  {
+    "label": "States and Provinces \u2013 Voice",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "WORDS",
+    "lesson": "STATE AND PROVINCES",
+    "preset": "VOICE AFTER WORDS 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=STATE%20AND%20PROVINCES&selectedPreset=VOICE%20AFTER%20WORDS%2023wpm",
+    "ok": true,
+    "notes": "Speed not specified in list; used 23wpm voice-after"
+  },
+  {
+    "label": "Sending: Letters (27)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "SENDING",
+    "lesson": "SENDING ALPHABET 1",
+    "preset": "SENDING ALPHABET 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20ALPHABET%201&selectedPreset=SENDING%20ALPHABET%2027wpm",
+    "ok": true,
+    "notes": "Uses SENDING ALPHABET 1 (SENDING ALPHABET 2 also exists)"
+  },
+  {
+    "label": "Sending: Numbers (27)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "SENDING",
+    "lesson": "SENDING NUMBERS 1",
+    "preset": "SENDING NUMBERS 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20NUMBERS%201&selectedPreset=SENDING%20NUMBERS%2027wpm",
+    "ok": true,
+    "notes": "Uses SENDING NUMBERS 1"
+  },
+  {
+    "label": "Sending Tri-Letters (27)",
+    "section": "Level INT1 & 2 Exercises",
+    "group": "SENDING",
+    "lesson": "SENDING TRI-LETTERS",
+    "preset": "SENDING Tri-Letters 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=SENDING%20TRI-LETTERS&selectedPreset=SENDING%20Tri-Letters%2027wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "3-4 letter words #1 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "WORDS",
+    "lesson": "3-4 LETTER WORDS PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=3-4%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "3-4 letter words #2 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "WORDS",
+    "lesson": "3-4 LETTER WORDS PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=3-4%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "4 letter words #1 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "WORDS",
+    "lesson": "4 LETTER WORDS PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "4 letter words #2 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "WORDS",
+    "lesson": "4 LETTER WORDS PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Many 4-Ltr words (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "WORDS",
+    "lesson": "MANY 4 LETTER WORDS",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=MANY%204%20LETTER%20WORDS&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "4-5 letter words (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "WORDS",
+    "lesson": "4-5 LETTER WORDS PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=4-5%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": "PART 2 also exists if needed"
+  },
+  {
+    "label": "Binomial Expressions #1 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "BINOMIALS",
+    "lesson": "BINOMIALS PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=BINOMIALS&selectedLesson=BINOMIALS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Binomial Expressions #2 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "BINOMIALS",
+    "lesson": "BINOMIALS PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=BINOMIALS&selectedLesson=BINOMIALS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Short phrases #1 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "PHRASES",
+    "lesson": "SHORT PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=SHORT%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Short phrases #2 (31-27-23 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "PHRASES",
+    "lesson": "SHORT PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=SHORT%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Sending 3 to 5-letter words (27 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "SENDING",
+    "lesson": "3-5 WORDS",
+    "preset": "SENDING WORDS/PHRASES 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=3-5%20WORDS&selectedPreset=SENDING%20WORDS%2FPHRASES%2027wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Sending 5 to 7-letter words (27 WPM)",
+    "section": "Level INT2 & 3 Exercises",
+    "group": "SENDING",
+    "lesson": "5-7 WORDS",
+    "preset": "SENDING WORDS/PHRASES 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENDING&selectedLesson=5-7%20WORDS&selectedPreset=SENDING%20WORDS%2FPHRASES%2027wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "3-word phrases #1 (31-27-23 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "PHRASES",
+    "lesson": "3 WORD PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "3-word phrases #2 (31-27-23 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "PHRASES",
+    "lesson": "3 WORD PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "3-word phrases CW/Voice/CW (27/25 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "PHRASES",
+    "lesson": "3 WORD CW-VOICE-CW",
+    "preset": "PHRASES CW-VOICE-CW 27/25wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=PHRASES&selectedLesson=3%20WORD%20CW-VOICE-CW&selectedPreset=PHRASES%20CW-VOICE-CW%2027%2F25wpm",
+    "ok": true,
+    "notes": "New Farnsworth preset"
+  },
+  {
+    "label": "Sentences CW/Voice/CW (27/25 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SENTENCES",
+    "lesson": "SENTENCES CW-VOICE-CW",
+    "preset": "SENTENCES CW-VOICE-CW 27/25wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2027%2F25wpm",
+    "ok": true,
+    "notes": "New Farnsworth preset"
+  },
+  {
+    "label": "Word length builder #1 (31-27-23 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "WORD BUILDING",
+    "lesson": "WORD BUILDING BASIC",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORD%20BUILDING&selectedLesson=WORD%20BUILDING%20BASIC&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Word length builder #2 (31-27-23 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "WORD BUILDING",
+    "lesson": "WORD BUILDING INTERMEDIATE",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORD%20BUILDING&selectedLesson=WORD%20BUILDING%20INTERMEDIATE&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": "Renamed from INTERMEDIAT (trailing space removed)"
+  },
+  {
+    "label": "5 letter words #1 (31-27-23 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "WORDS",
+    "lesson": "5 LETTER WORDS PART 1",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=5%20LETTER%20WORDS%20PART%201&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "5 letter words #2 (31-27-23)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "WORDS",
+    "lesson": "5 LETTER WORDS PART 2",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=5%20LETTER%20WORDS%20PART%202&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "ING suffix exercise #1 (31-27-23)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SUFFIXES",
+    "lesson": "ING",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=ING&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": "Only one ING wordfile exists; #1 and #2 share content"
+  },
+  {
+    "label": "ING suffix exercise #2 (31-27-23)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SUFFIXES",
+    "lesson": "ING",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=ING&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": "Same content as #1 until a second ING part is added"
+  },
+  {
+    "label": "Common suffixes (27)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SUFFIXES",
+    "lesson": "SUFFIXES ALL",
+    "preset": "SUFFIXES 27wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SUFFIXES&selectedLesson=SUFFIXES%20ALL&selectedPreset=SUFFIXES%2027wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Top 100 words (31-27-23 WPM)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "WORDS",
+    "lesson": "TOP 100 WORDS",
+    "preset": "SPEED RACING 23wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=WORDS&selectedLesson=TOP%20100%20WORDS&selectedPreset=SPEED%20RACING%2023wpm",
+    "ok": true,
+    "notes": ""
+  },
+  {
+    "label": "Top 100 word sentences \u2013 CW/Voice/CW \u2013 (23/21)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SENTENCES",
+    "lesson": "SHORT SENTENCES CW-VOICE-CW",
+    "preset": "SENTENCES CW-VOICE-CW 23/21wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2023%2F21wpm",
+    "ok": true,
+    "notes": "New Farnsworth preset"
+  },
+  {
+    "label": "Top 100 word sentences \u2013 CW/Voice/CW \u2013 (27/25)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SENTENCES",
+    "lesson": "SHORT SENTENCES CW-VOICE-CW",
+    "preset": "SENTENCES CW-VOICE-CW 27/25wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2027%2F25wpm",
+    "ok": true,
+    "notes": "New Farnsworth preset"
+  },
+  {
+    "label": "Top 100 word sentences \u2013 CW/Voice/CW \u2013 (31/28)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SENTENCES",
+    "lesson": "SHORT SENTENCES CW-VOICE-CW",
+    "preset": "SENTENCES CW-VOICE-CW 31/28wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=SHORT%20SENTENCES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2031%2F28wpm",
+    "ok": true,
+    "notes": "New Farnsworth preset"
+  },
+  {
+    "label": "One-Liner Jokes \u2013 CW/Voice/CW (23/21)",
+    "section": "Level INT3 & ADV1 Exercises",
+    "group": "SENTENCES",
+    "lesson": "JOKES CW-VOICE-CW",
+    "preset": "SENTENCES CW-VOICE-CW 23/21wpm",
+    "url": "https://longislandcw.github.io/morsebrowser/index.html?selectedClass=OVERLEARN&selectedGroup=SENTENCES&selectedLesson=JOKES%20CW-VOICE-CW&selectedPreset=SENTENCES%20CW-VOICE-CW%2023%2F21wpm",
+    "ok": true,
+    "notes": "New Farnsworth preset"
+  }
+]

--- a/tests/unit/lessons/overlearnRichLinks.test.ts
+++ b/tests/unit/lessons/overlearnRichLinks.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(__dirname, '../../..')
+
+function loadJson (rel: string) {
+  return JSON.parse(readFileSync(resolve(root, rel), 'utf8'))
+}
+
+function overlearnLessons (): Array<{ display: string, letterGroup: string, fileName: string }> {
+  const raw = readFileSync(resolve(root, 'src/wordfilesconfigs/wordlists.json'), 'utf8')
+  const lessons: Array<{ display: string, letterGroup: string, fileName: string, userTarget?: string }> = []
+  const re = /\{[^{}]*"class":\s*"OVERLEARN"[^{}]*\}/g
+  for (const m of raw.matchAll(re)) {
+    const o = JSON.parse(m[0])
+    if (o.userTarget === 'STUDENT') {
+      lessons.push(o)
+    }
+  }
+  return lessons
+}
+
+describe('OverLearn rich links catalog', () => {
+  const links = loadJson('tests/fixtures/overlearnRichLinks.json') as Array<{
+    label: string
+    group: string
+    lesson: string
+    preset: string
+    url: string
+    ok: boolean
+  }>
+  const presets = loadJson('src/presets/sets/POL.json').options as Array<{ display: string, filename: string }>
+  const lessons = overlearnLessons()
+  const lessonByDisplay = Object.fromEntries(lessons.map((l) => [l.display, l]))
+  const presetByDisplay = Object.fromEntries(presets.map((p) => [p.display, p]))
+
+  it('has only valid entries', () => {
+    expect(links.length).toBeGreaterThan(40)
+    for (const link of links) {
+      expect(link.ok, link.label).toBe(true)
+      expect(link.url).toContain('selectedClass=OVERLEARN')
+      expect(link.url).toContain('selectedGroup=')
+      expect(link.url).toContain('selectedLesson=')
+      expect(link.url).toContain('selectedPreset=')
+    }
+  })
+
+  it('resolves every lesson and preset against live configs', () => {
+    for (const link of links) {
+      const lesson = lessonByDisplay[link.lesson]
+      expect(lesson, `${link.label} lesson ${link.lesson}`).toBeTruthy()
+      expect(lesson.letterGroup, link.label).toBe(link.group)
+
+      const preset = presetByDisplay[link.preset]
+      expect(preset, `${link.label} preset ${link.preset}`).toBeTruthy()
+
+      const wordfile = resolve(root, 'src/wordfiles', lesson.fileName)
+      const presetFile = resolve(root, 'src/presets/configs', preset.filename)
+      expect(readFileSync(wordfile, 'utf8').length, wordfile).toBeGreaterThan(0)
+      expect(loadJson(`src/presets/configs/${preset.filename}`).morseSettings.length).toBeGreaterThan(0)
+      expect(presetFile).toBeTruthy()
+    }
+  })
+
+  it('includes Tom INT1/2 Alphabet and Numbers entries', () => {
+    const labels = links.map((l) => l.label)
+    expect(labels).toContain('Alphabet (23 WPM)')
+    expect(labels).toContain('Alphabet Mix #1 (23-27-31 WPM)')
+    expect(labels).toContain('Alphabet Mix #2 (23-27-23 WPM)')
+    expect(labels).toContain('Numbers (23 WPM)')
+    expect(labels).toContain('Numbers (27 WPM)')
+  })
+})

--- a/tests/unit/lessons/presetDeepLink.test.ts
+++ b/tests/unit/lessons/presetDeepLink.test.ts
@@ -1,0 +1,215 @@
+import * as ko from 'knockout'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GeneralUtils } from '../../../src/morse/utils/general'
+import { MorseSettings } from '../../../src/morse/settings/settings'
+import MorseLessonPlugin from '../../../src/morse/lessons/morseLessonPlugin'
+
+const polOptions = [
+  { display: 'BINOMIALS 23wpm', filename: 'POL_Random_3x_23.json' },
+  { display: 'CHARACTERS 23wpm', filename: 'POL_Random_23.json' },
+  { display: 'CHARACTERS 27wpm', filename: 'POL_Random_27.json' }
+]
+
+let pendingPresetSetCallbacks: Array<(data: { data: { options: typeof polOptions } }) => void> = []
+
+vi.mock('../../../src/morse/morsePresetSetFinder', () => ({
+  MorsePresetSetFileFinder: {
+    getMorsePresetSetFile: (_file: string, cb: (data: { data: { options: typeof polOptions } }) => void) => {
+      pendingPresetSetCallbacks.push(cb)
+    }
+  }
+}))
+
+vi.mock('../../../src/morse/morsePresetFinder', () => ({
+  MorsePresetFileFinder: {
+    getMorsePresetFile: (_fileName: string, cb: (d: { found: boolean, data: { morseSettings: Array<{ key: string, value: unknown }> } }) => void) => {
+      cb({
+        found: true,
+        data: {
+          morseSettings: [
+            { key: 'wpm', value: 23 },
+            { key: 'fwpm', value: 23 },
+            { key: 'syncWpm', value: true }
+          ]
+        }
+      })
+    }
+  }
+}))
+
+vi.mock('../../../src/morse/cookies/morseCookies', () => ({
+  MorseCookies: {
+    registeredHandlers: [],
+    registerHandler: vi.fn(),
+    loadCookiesOrDefaults: vi.fn((info: {
+      custom?: Array<{ key: string, value: unknown }>
+      ctxt: { settings: { speed: { wpm: (v: unknown) => void, fwpm: (v: unknown) => void } } }
+      afterSettingsChange?: () => void
+    }) => {
+      for (const s of info.custom || []) {
+        if (s.key === 'wpm') {
+          info.ctxt.settings.speed.wpm(s.value)
+        }
+        if (s.key === 'fwpm') {
+          info.ctxt.settings.speed.fwpm(s.value)
+        }
+      }
+      info.afterSettingsChange?.()
+    })
+  }
+}))
+
+function flushPendingPresetSets () {
+  const callbacks = pendingPresetSetCallbacks
+  pendingPresetSetCallbacks = []
+  for (const cb of callbacks) {
+    cb({ data: { options: polOptions } })
+  }
+}
+
+function createOverlearnPlugin () {
+  const misc = {
+    newlineChunking: ko.observable(false),
+    isMoreSettingsAccordionOpen: false
+  }
+  const morseSettings = { misc } as MorseSettings
+  const morseViewModel = {
+    allowSaveCookies: ko.observable(true),
+    lockoutSaveCookiesTimerHandle: null as ReturnType<typeof setTimeout> | null,
+    currentSerializedSettings: null,
+    lessons: null as MorseLessonPlugin | null,
+    morseVoice: {
+      voiceEnabled: ko.observable(false),
+      voiceSpelling: ko.observable(false),
+      voiceThinkingTime: ko.observable(0),
+      voiceAfterThinkingTime: ko.observable(0),
+      voiceVolume: ko.observable(5),
+      voiceLastOnly: ko.observable(false),
+      manualVoice: ko.observable(false),
+      speakFirst: ko.observable(false),
+      speakFirstAdditionalWordspaces: ko.observable(0),
+      voiceBufferMaxLength: ko.observable(10)
+    },
+    settings: {
+      speed: {
+        wpm: ko.observable(20),
+        fwpm: ko.observable(15),
+        syncWpm: ko.observable(true),
+        speedInterval: ko.observable(false),
+        intervalTimingsText: ko.observable(''),
+        intervalWpmText: ko.observable(''),
+        intervalFwpmText: ko.observable(''),
+        speedRacerEnabled: ko.observable(false),
+        speedRacerMultipliers: ko.observable('1.5, 1.35, 1.175, 1.0'),
+        speedRacerFinalPlay: ko.observable(true),
+        speedRacerSpeakBeforeReplay: ko.observable(true),
+        speedRacerKeepFwpm: ko.observable(true)
+      },
+      misc
+    },
+    xtraWordSpaceDits: ko.observable(0),
+    volume: ko.observable(5),
+    hideList: ko.observable(false),
+    showRaw: ko.observable(false),
+    darkMode: ko.observable(false),
+    autoCloseSettingsAccordions: ko.observable(true),
+    showExpertSettings: ko.observable(false),
+    numberOfRepeats: ko.observable(0),
+    cardSpace: ko.observable(1),
+    isShuffled: ko.observable(false),
+    shuffleIntraGroup: ko.observable(false),
+    cachedShuffle: false,
+    lessonVoiceBaseline: null,
+    captureLessonVoiceBaseline: vi.fn(),
+    restoreLessonVoiceFromLesson: vi.fn(),
+    announce: vi.fn()
+  }
+
+  const plugin = new MorseLessonPlugin(
+    morseSettings,
+    () => {},
+    () => ({ timeCalcs: { totalTime: 0 } }),
+    morseViewModel as never
+  )
+  morseViewModel.lessons = plugin
+  plugin.wordLists([
+    {
+      sort: 1,
+      userTarget: 'STUDENT',
+      class: 'OVERLEARN',
+      letterGroup: 'CHARACTERS',
+      newlineChunking: true,
+      display: 'ALPHABET',
+      fileName: 'POL_Letters.txt'
+    },
+    {
+      sort: 2,
+      userTarget: 'STUDENT',
+      class: 'OVERLEARN',
+      letterGroup: 'CHARACTERS',
+      newlineChunking: true,
+      display: 'NUMBERS',
+      fileName: 'POL_Numbers.txt'
+    }
+  ] as never)
+
+  return { plugin, morseViewModel }
+}
+
+describe('OverLearn preset deep links', () => {
+  let getParamSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    pendingPresetSetCallbacks = []
+    getParamSpy = vi.spyOn(GeneralUtils, 'getParameterByName').mockImplementation((name: string) => {
+      const params: Record<string, string> = {
+        selectedClass: 'OVERLEARN',
+        selectedGroup: 'CHARACTERS',
+        selectedLesson: 'ALPHABET',
+        selectedPreset: 'CHARACTERS 23wpm'
+      }
+      return params[name] ?? null
+    })
+  })
+
+  afterEach(() => {
+    getParamSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('applies selectedPreset after async preset-set load (not stuck on Your Settings)', () => {
+    const { plugin, morseViewModel } = createOverlearnPlugin()
+
+    // Reproduce production race: init query handlers before preset-set file returns.
+    plugin.setUserTargetInitialized()
+    plugin.setSelectedClassInitialized()
+    plugin.setLetterGroupInitialized()
+    plugin.setDisplaysInitialized()
+    plugin.ensureSettingsPresetsInitialized()
+
+    expect(plugin.selectedSettingsPreset().display).toBe('Your Settings')
+    expect(morseViewModel.settings.speed.wpm()).toBe(20)
+    expect(morseViewModel.settings.speed.fwpm()).toBe(15)
+    expect(pendingPresetSetCallbacks.length).toBeGreaterThan(0)
+
+    flushPendingPresetSets()
+
+    expect(plugin.selectedSettingsPreset().display).toBe('CHARACTERS 23wpm')
+    expect(morseViewModel.settings.speed.wpm()).toBe(23)
+    expect(morseViewModel.settings.speed.fwpm()).toBe(23)
+  })
+
+  it('does not auto-select the first preset when selectedPreset is in the URL', () => {
+    const { plugin } = createOverlearnPlugin()
+    plugin.setUserTargetInitialized()
+    plugin.setSelectedClassInitialized()
+    plugin.setLetterGroupInitialized()
+    plugin.setDisplaysInitialized()
+    plugin.ensureSettingsPresetsInitialized()
+    flushPendingPresetSets()
+
+    // First non-Your option is BINOMIALS 23wpm; deep link asked for CHARACTERS.
+    expect(plugin.selectedSettingsPreset().display).not.toBe('BINOMIALS 23wpm')
+    expect(plugin.selectedSettingsPreset().display).toBe('CHARACTERS 23wpm')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tom-style OverLearn deep links (e.g. Alphabet / Numbers with `selectedPreset=CHARACTERS 23wpm`) showed the preset in the URL but left:

- PRESETS on **Your Settings**
- WPM / FWPM at whatever was last used

Separately, Tom’s full OverLearn exercise list needed validated MPP rich links.

## Cause (preset bug)

`setSettingsPresetsInitialized()` ran during lesson-picker init **before** the async preset-set file (`POL.json`) finished loading. The URL preset was not in the list yet. When the list arrived later, init was already marked done and auto-select was blocked by the `selectedPreset` guard — so settings never applied.

## Fix

- Retry URL preset selection after the preset-set list loads
- Prefer the URL preset over “first non-Your Settings” auto-select
- Regression tests for the async race

## Rich links (this follow-up)

All **50** exercises from Tom’s INT1–ADV1 list are mapped and validated:

- Catalog: [`docs/OVERLEARN_RICH_LINKS.md`](../blob/cursor/fix-overlearn-preset-deeplink-3ea6/docs/OVERLEARN_RICH_LINKS.md)
- Clickable HTML for Word/email: [`docs/overlearn-rich-links.html`](../blob/cursor/fix-overlearn-preset-deeplink-3ea6/docs/overlearn-rich-links.html)

Also added missing presets Tom’s list needed:

| Need | Preset |
|------|--------|
| Alphabet Mix #2 (23-27-23) | `SPEED RACING PEAK 23wpm` |
| CW/Voice/CW Farnsworth 23/21, 27/25, 31/28 | `SENTENCES CW-VOICE-CW …` / `PHRASES CW-VOICE-CW 27/25wpm` |

Fixed lesson display typos that would break URLs: trailing space on `WORD BUILDING INTERMEDIATE`, double space in `4-5 LETTER WORDS PART 1`.

## Example

```
?selectedClass=OVERLEARN&selectedGroup=CHARACTERS&selectedLesson=ALPHABET&selectedPreset=CHARACTERS%2023wpm
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f86f9-9246-73b3-93a7-fb7892a53ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f86f9-9246-73b3-93a7-fb7892a53ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

